### PR TITLE
Turn on and off OBS source when application starts/ends

### DIFF
--- a/src/OverBlaze/OverBlaze.csproj
+++ b/src/OverBlaze/OverBlaze.csproj
@@ -1,4 +1,4 @@
-<Project Sdk="Microsoft.NET.Sdk.Web">
+﻿<Project Sdk="Microsoft.NET.Sdk.Web">
 
   <PropertyGroup>
     <TargetFramework>net6.0</TargetFramework>
@@ -12,6 +12,7 @@
     <PackageReference Include="TwitchLib.Api" Version="3.2.3" />
     <PackageReference Include="TwitchLib.Client" Version="3.2.1" />
     <PackageReference Include="TwitchLib.PubSub" Version="3.2.3-preview-5500be4a524d8812e7bd37de4288610422b41fe6" />
+    <PackageReference Include="obs-websocket-dotnet" Version="4.9.0" />
   </ItemGroup>
 
 </Project>

--- a/src/OverBlaze/OverBlaze.csproj
+++ b/src/OverBlaze/OverBlaze.csproj
@@ -3,6 +3,7 @@
   <PropertyGroup>
     <TargetFramework>net6.0</TargetFramework>
     <Nullable>enable</Nullable>
+    <UserSecretsId>5bdb0101-99dc-4b22-a60e-119111074c0d</UserSecretsId>
   </PropertyGroup>
 
   <ItemGroup>

--- a/src/OverBlaze/Services/ExtensionContentType.cs
+++ b/src/OverBlaze/Services/ExtensionContentType.cs
@@ -12,6 +12,7 @@ namespace OverBlaze.Services
             [".png"] = "image/png",
             [".gif"] = "image/gif",
             [".mp3"] = "audio/mpeg",
+            [".jpg"] = "image/jpeg"
         };
 
         public static bool TryGet(string fileName, [NotNullWhen(true)] out string? contentType)

--- a/src/OverBlaze/Services/TwitchAuth.cs
+++ b/src/OverBlaze/Services/TwitchAuth.cs
@@ -8,7 +8,7 @@ namespace OverBlaze.Services
 {
     public class TwitchAuth
     {
-        private const string ClientId = "7mtekewyfkadmhxarxyrektpsrb9vq";
+        private readonly string ClientId;
         
         private readonly IConfiguration _configuration;
         private readonly ILocalStorageService _localStorageService;
@@ -17,6 +17,7 @@ namespace OverBlaze.Services
         public TwitchAuth(IConfiguration configuration)
         {
             _configuration = configuration;
+            ClientId =  _configuration.GetValue<string>("Twitch:ClientId") ?? "7mtekewyfkadmhxarxyrektpsrb9vq";
         }
 
         public bool TrySetTokens(string? idToken, string? accessToken)

--- a/src/OverBlaze/Startup.cs
+++ b/src/OverBlaze/Startup.cs
@@ -115,8 +115,13 @@ namespace OverBlaze
         private void ToggleOBSSource(bool toggle)
         {
             OBSWebsocket obsWebsocket = new OBSWebsocket();
+            var browserSourceName = "OverBlaze";
             obsWebsocket.Connect(Configuration.GetValue<string>("OBS:WebSocketUrl"), Configuration.GetValue<string>("OBS:WebSocketPassword"));
-            obsWebsocket.SetSourceRender("OverBlaze", toggle);
+            obsWebsocket.SetSourceRender(browserSourceName, toggle);
+            if(toggle)
+            {
+                obsWebsocket.RefreshBrowserSource(browserSourceName);
+            }
             obsWebsocket.Disconnect();
         }
     }

--- a/src/OverBlaze/Startup.cs
+++ b/src/OverBlaze/Startup.cs
@@ -16,6 +16,7 @@ using Microsoft.Extensions.Configuration;
 using Microsoft.Extensions.DependencyInjection;
 using Microsoft.Extensions.Hosting;
 using Microsoft.Net.Http.Headers;
+using OBSWebsocketDotNet;
 using OverBlaze.Data;
 using OverBlaze.Endpoints;
 using OverBlaze.Services;
@@ -55,6 +56,8 @@ namespace OverBlaze
             IHostApplicationLifetime applicationLifetime)
         {
             applicationLifetime.ApplicationStarted.Register(() => StartBrowser(app));
+            applicationLifetime.ApplicationStarted.Register(() => ToggleOBSSource(true));
+            applicationLifetime.ApplicationStopping.Register(() => ToggleOBSSource(false));
             
             if (env.IsDevelopment())
             {
@@ -107,6 +110,14 @@ namespace OverBlaze
             }
 
             Process.Start(start);
+        }
+
+        private void ToggleOBSSource(bool toggle)
+        {
+            OBSWebsocket obsWebsocket = new OBSWebsocket();
+            obsWebsocket.Connect(Configuration.GetValue<string>("OBS:WebSocketUrl"), Configuration.GetValue<string>("OBS:WebSocketPassword"));
+            obsWebsocket.SetSourceRender("OverBlaze", toggle);
+            obsWebsocket.Disconnect();
         }
     }
 }


### PR DESCRIPTION
Uses OBS Websocket plugin. Once installed, you need to put in config "OBS:WebSocketUrl" (ws://127.0.0.1:4444 unless you have changed port) and "OBS:WebSocketPassword" (can be set in Tools / WebSocket Server Settings in OBS) and code assumes source pointing at Overlay page will be called "OverBlaze" though this could be made configurable.

Couple of other fixes to allow jpg images to be used and to enable running on other computers (allowing Twitch Client Id to be set
and enabling setting config via user-secrets tool)